### PR TITLE
update git workflows node version, remove automated npm update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3.4.1
+      - uses: actions/setup-node@v4.1.0
         with:
-          node-version: 20.11.0
-      - name: install npm version
-        run: npm install -g npm
+          node-version: 20.17.0
       - name: Get Version
         run: npm -v
       - name: Install modules


### PR DESCRIPTION
### Bug Fixes
- workflows npm update is installing npm 11 which breaks 

### Improvements
- update git workflows node version
- remove automated npm update

