### PR TITLE
Update docs links to use new Gen3 docs sites

### DIFF
--- a/config/gen3/discovery.json
+++ b/config/gen3/discovery.json
@@ -42,7 +42,7 @@
           "downloadZipButtonText": "Download Zip",
           "downloadManifestButtonText": "Download Manifest",
           "documentationLinks": {
-            "gen3Client": "https://gen3.org/resources/user/gen3-client/",
+            "gen3Client": "https://docs.gen3.org/gen3-resources/tools/data-client/",
             "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
           },
           "verifyExternalLogins": true


### PR DESCRIPTION
Update docs links from old Gen3 docs site (gen3.org/resources) to use new Gen3 docs sites (docs.gen3.org)
